### PR TITLE
fixed building with VS13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
 procrastitracker/Release
 procrastitracker/Debug
+PT/procrastitracker.exe
+ipch/
 *.pdb
 *.ncb
 *.iobj
 *.ipdb
-
+*.suo
+*.sdf
+*.opensdf
+*.aps

--- a/procrastitracker/procrastitracker.vcxproj
+++ b/procrastitracker/procrastitracker.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -42,12 +42,12 @@
     <_ProjectFileVersion>14.0.23107.0</_ProjectFileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <OutDir>$(SolutionDir)..\PT\</OutDir>
     <IntDir>$(Configuration)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <OutDir>$(SolutionDir)..\PT\</OutDir>
     <IntDir>$(Configuration)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
@@ -65,7 +65,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>Psapi.lib;comctl32.lib;Comdlg32.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>..\PT\$(ProjectName).exe</OutputFile>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <AdditionalLibraryDirectories>lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(TargetName)_dbg.pdb</ProgramDatabaseFile>
@@ -86,7 +86,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>Psapi.lib;comctl32.lib;Comdlg32.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>..\PT\$(ProjectName).exe</OutputFile>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <AdditionalLibraryDirectories>lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/src/nodedb.h
+++ b/src/nodedb.h
@@ -71,7 +71,7 @@ void load(node *root, char *fn, bool merge)
         if (merge)  // don't overwrite global data
         {
             int ntags = rint(f);
-            uint bytes = ntags * (sizeof(tag::name) + sizeof(int));  // tags
+            uint bytes = ntags * (sizeof(tag().name) + sizeof(int)); // tags
             bytes += version < 6 ? 10 : sizeof(int);                 // minfilter
             bytes += sizeof(int);                                    // foldlevel
             if (version >= 6)                                        // prefs


### PR DESCRIPTION
When trying to build on VS13 a compiler error will be thrown on `sizeof(tag::name)`, I replaced this with `sizeof(tag().name)` which does exactly the same. Also fixed a compile bug when the `LinkOutput` property  does not match the `TargetPath` property:

`warning MSB8012: TargetPath(X) does not match the Linker's OutputFile property value (Y). This may cause your project to build incorrectly. To correct this, please make sure that $(OutDir), $(TargetName) and $(TargetExt) property values match the value specified in %(Link.OutputFile).`

Obviously not a required fix since you say VS15 is a requirement, but it is not breaking for VS15 building and might save people the time of installing that piece of bloatware :smile: 