### PR TITLE
fix for mousewheel, suggested by Aleksandra Kalicinska

### DIFF
--- a/src/IdleTracker.cpp
+++ b/src/IdleTracker.cpp
@@ -69,7 +69,7 @@ LRESULT CALLBACK MouseTracker(int code, WPARAM wParam, LPARAM lParam)
         DWORD curtime = GetTickCount();
         CheckAway(g_dwLastTick, curtime);
 
-        MOUSEHOOKSTRUCTEX *pStruct = (MOUSEHOOKSTRUCTEX *)lParam;
+        MSLLHOOKSTRUCT *pStruct = (MSLLHOOKSTRUCT *)lParam;
         switch (wParam)
         {
             case WM_LBUTTONDOWN: lmb++; break;
@@ -88,9 +88,19 @@ LRESULT CALLBACK MouseTracker(int code, WPARAM wParam, LPARAM lParam)
 }
 
 bool inputhooksetup()
-{
-    if (!g_hHkKeyboardLL) g_hHkKeyboardLL = SetWindowsHookEx(WH_KEYBOARD_LL, KeyboardTracker, NULL, 0);
-    if (!g_hHkMouseLL) g_hHkMouseLL = SetWindowsHookEx(WH_MOUSE_LL, MouseTracker, NULL, 0);
+{ // WINVER = 0x0501 for Windows XP, it needs non-NULL hInst arg
+  // in order to work;  what about newer versions of Windows?
+  // if there is a problem for some other version, try changing
+  // the 0x0501 to this version number, maybe it will help
+  // for VINVER < 0x0501  ICC_STANDARD_CLASSES  is undefined
+  // in procrastitracker.cpp, so it cannot be used below Win XP
+#if WINVER <= 0x0501
+    extern HINSTANCE hInst;
+#else
+#define hInst NULL
+#endif
+    if (!g_hHkKeyboardLL) g_hHkKeyboardLL = SetWindowsHookEx(WH_KEYBOARD_LL, KeyboardTracker, hInst, 0);
+    if (!g_hHkMouseLL) g_hHkMouseLL = SetWindowsHookEx(WH_MOUSE_LL, MouseTracker, hInst, 0);
 
     g_dwLastTick = GetTickCount();
 


### PR DESCRIPTION
There are two changes to src/Idletracker.cpp, suggested by Aleksandra Kalicinska in phone talk:
use of different structure (now MSLLHOOKSTRUCT) in MouseTracker() and hInst instead NULL
as arg 3 of SetWindowsHookEx(); the first fixes a bug causing ignoring mouse wheel (the original
structure has fields of same names, but this for mouse wheel is at different offset); the second
fixes a problem occuring at least on Windows XP: the SetWindowsHookEx() returned NULL when
arg 3 was NULL and arg 4 was 0; possibly newer Windows versions work correctly when arg 3
is NULL, therefore I compare WINVER to limit the change to Windows XP.