### PR TITLE
Mingw

### DIFF
--- a/src/IdleTracker.cpp
+++ b/src/IdleTracker.cpp
@@ -69,7 +69,7 @@ LRESULT CALLBACK MouseTracker(int code, WPARAM wParam, LPARAM lParam)
         DWORD curtime = GetTickCount();
         CheckAway(g_dwLastTick, curtime);
 
-        MOUSEHOOKSTRUCTEX *pStruct = (MOUSEHOOKSTRUCTEX *)lParam;
+        MSLLHOOKSTRUCT *pStruct = (MSLLHOOKSTRUCT *)lParam;
         switch (wParam)
         {
             case WM_LBUTTONDOWN: lmb++; break;
@@ -88,9 +88,19 @@ LRESULT CALLBACK MouseTracker(int code, WPARAM wParam, LPARAM lParam)
 }
 
 bool inputhooksetup()
-{
-    if (!g_hHkKeyboardLL) g_hHkKeyboardLL = SetWindowsHookEx(WH_KEYBOARD_LL, KeyboardTracker, NULL, 0);
-    if (!g_hHkMouseLL) g_hHkMouseLL = SetWindowsHookEx(WH_MOUSE_LL, MouseTracker, NULL, 0);
+{ // WINVER = 0x0501 for Windows XP, it needs non-NULL hInst arg
+  // in order to work;  what about newer versions of Windows?
+  // if there is a problem for some other version, try changing
+  // the 0x0501 to this version number, maybe it will help
+  // for VINVER < 0x0501  ICC_STANDARD_CLASSES  is undefined
+  // in procrastitracker.cpp, so it cannot be used below Win XP
+#if WINVER <= 0x0501
+    extern HINSTANCE hInst;
+#else
+#define hInst NULL
+#endif
+    if (!g_hHkKeyboardLL) g_hHkKeyboardLL = SetWindowsHookEx(WH_KEYBOARD_LL, KeyboardTracker, hInst, 0);
+    if (!g_hHkMouseLL) g_hHkMouseLL = SetWindowsHookEx(WH_MOUSE_LL, MouseTracker, hInst, 0);
 
     g_dwLastTick = GetTickCount();
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,20 @@
+# This Makefile is to compile procrastitracker with MinGW:
+# * need set PATH to contain directories with MinGW/MSYS binaries
+# * enter the "src" directory where this Makefile is
+# * use "make" alone to make "pt.exe" (main executable)
+# * use "make clean" to delete intermediate files
+
+main: pt.exe
+
+clean:
+	del *.o resource.h ..\\procrastitracker\\pt-resource.o
+
+# source files used to build procrastitracker executable pt.exe
 # cpp: IdleTracker.cpp inputdlg.cpp procrastitracker.cpp stdafx.cpp
 # h: IdleTracker.h away.h day.h ddeutil.h inputdlg.h node.h
 # h: nodedb.h prefview.h regview.h slaballoc.h statview.h stdafx.h
-# h: timercallback.h tools.h win32tools.h
+# h: timercallback.h tools.h win32tools.h ../procrastitracker/resource.h
+# rc: ../procrastitracker/procrastitracker.rc (and likely more there)
 
 # need _WIN32_WINNT >= 0x0501, or ICC_STANDARD_CLASSES is undefined
 COPT=-DWINVER=0x0501 -D_WIN32_WINNT=0x0501 -D_WIN32_IE=0x500 -DMINGW32_BUG
@@ -12,8 +25,7 @@ pt.exe: procrastitracker.o IdleTracker.o inputdlg.o stdafx.o	\
 	 ../procrastitracker/pt-resource.o  -o pt.exe			\
 	 -lz -lpsapi -lcomctl32 -lcomdlg32 -lshlwapi -loleacc		\
 	 -lole32 -lgdi32 -lstdc++ -Wl,--subsystem,windows
-# -lwin32k no; + psapi comctl32 comdlg32 shlwapi
-# + oleacc ole32 gdi32 stdc++
+
 IdleTracker.o: Makefile IdleTracker.cpp
 	g++ $(COPT) -Wno-write-strings -c IdleTracker.cpp
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,7 +7,7 @@
 main: pt.exe
 
 clean:
-	del *.o resource.h ..\\procrastitracker\\pt-resource.o
+	rm -f *.o resource.h ../procrastitracker/pt-resource.o
 
 # source files used to build procrastitracker executable pt.exe
 # cpp: IdleTracker.cpp inputdlg.cpp procrastitracker.cpp stdafx.cpp
@@ -15,6 +15,7 @@ clean:
 # h: nodedb.h prefview.h regview.h slaballoc.h statview.h stdafx.h
 # h: timercallback.h tools.h win32tools.h ../procrastitracker/resource.h
 # rc: ../procrastitracker/procrastitracker.rc (and likely more there)
+# lib: z psapi comctl32 comdlg32 shlwapi oleacc ole32 gdi32 stdc++
 
 # need _WIN32_WINNT >= 0x0501, or ICC_STANDARD_CLASSES is undefined
 COPT=-DWINVER=0x0501 -D_WIN32_WINNT=0x0501 -D_WIN32_IE=0x500 -DMINGW32_BUG

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,36 @@
+# cpp: IdleTracker.cpp inputdlg.cpp procrastitracker.cpp stdafx.cpp
+# h: IdleTracker.h away.h day.h ddeutil.h inputdlg.h node.h
+# h: nodedb.h prefview.h regview.h slaballoc.h statview.h stdafx.h
+# h: timercallback.h tools.h win32tools.h
+
+# need _WIN32_WINNT >= 0x0501, or ICC_STANDARD_CLASSES is undefined
+COPT=-DWINVER=0x0501 -D_WIN32_WINNT=0x0501 -D_WIN32_IE=0x500 -DMINGW32_BUG
+
+pt.exe: procrastitracker.o IdleTracker.o inputdlg.o stdafx.o	\
+	 ../procrastitracker/pt-resource.o
+	g++ procrastitracker.o IdleTracker.o inputdlg.o stdafx.o	\
+	 ../procrastitracker/pt-resource.o  -o pt.exe			\
+	 -lz -lpsapi -lcomctl32 -lcomdlg32 -lshlwapi -loleacc		\
+	 -lole32 -lgdi32 -lstdc++ -Wl,--subsystem,windows
+# -lwin32k no; + psapi comctl32 comdlg32 shlwapi
+# + oleacc ole32 gdi32 stdc++
+IdleTracker.o: Makefile IdleTracker.cpp
+	g++ $(COPT) -Wno-write-strings -c IdleTracker.cpp
+
+inputdlg.o: Makefile inputdlg.cpp inputdlg.h
+	g++ $(COPT) -fpermissive -c inputdlg.cpp
+
+procrastitracker.o: Makefile procrastitracker.cpp stdafx.h resource.h		\
+	 IdleTracker.h win32tools.h inputdlg.h slaballoc.h tools.h day.h node.h	\
+	 nodedb.h ddeutil.h timercallback.h statview.h prefview.h regview.h away.h
+	g++ $(COPT) -Wno-multichar -Wno-write-strings -c procrastitracker.cpp
+
+stdafx.o: Makefile stdafx.cpp stdafx.h
+	g++ $(COPT) -c stdafx.cpp
+
+resource.h: ../procrastitracker/resource.h
+	cp -a ../procrastitracker/resource.h ./
+
+../procrastitracker/pt-resource.o: ../procrastitracker/procrastitracker.rc	\
+	../procrastitracker/resource.h
+	cd ..\\procrastitracker; windres $(COPT) procrastitracker.rc -o pt-resource.o

--- a/src/ddeutil.h
+++ b/src/ddeutil.h
@@ -57,7 +57,12 @@ void ddereq(char *server, char *topic, char *item, char *buf, int len)
 HWINEVENTHOOK LHook = 0;
 char current_chrome_url[MAXTMPSTR] = { 0 };
 
-void CALLBACK WinEventProc(HWINEVENTHOOK hWinEventHook, DWORD event, HWND hwnd, LONG idObject, LONG idChild, DWORD dwEventThread, DWORD dwmsEventTime) {
+#ifdef MINGW32_BUG
+void WinEventProc
+#else
+void CALLBACK WinEventProc
+#endif
+(HWINEVENTHOOK hWinEventHook, DWORD event, HWND hwnd, LONG idObject, LONG idChild, DWORD dwEventThread, DWORD dwmsEventTime) {
     char classname[MAXTMPSTR];
     GetClassName(hwnd, classname, MAXTMPSTR);
     classname[MAXTMPSTR - 1] = 0;

--- a/src/node.h
+++ b/src/node.h
@@ -29,6 +29,7 @@ struct node : SlabAllocated<node>
     bool hidden;
     bool expanded;
     bool instrfilter;
+    static int nodesorter(node **a, node **b);
 
     node(char *_name, node *_p)
         : ht(NULL),
@@ -162,7 +163,7 @@ struct node : SlabAllocated<node>
             {
                 Vector<node *> v;
                 ht->getelements(v);
-                v.sort((void*)nodesorter);
+                v.sort((void *)nodesorter);
                 fprintf(f, "<table border=0 cellspacing=0 cellpadding=3>\n");
                 loopv(i, v)
                 {
@@ -429,7 +430,7 @@ struct node : SlabAllocated<node>
         {
             Vector<node *> v;
             ht->getelements(v);
-            v.sort((void*)nodesorter);
+            v.sort((void *)nodesorter);
             int timelevel = 0;
             if (v[0]->accum.seconds > 60) timelevel++;
             if (v[0]->accum.seconds > 60 * 60) timelevel++;

--- a/src/node.h
+++ b/src/node.h
@@ -29,7 +29,7 @@ struct node : SlabAllocated<node>
     bool hidden;
     bool expanded;
     bool instrfilter;
-    static int nodesorter(node **a, node **b);
+//    static int nodesorter(node **a, node **b);
 
     node(char *_name, node *_p)
         : ht(NULL),

--- a/src/node.h
+++ b/src/node.h
@@ -162,7 +162,7 @@ struct node : SlabAllocated<node>
             {
                 Vector<node *> v;
                 ht->getelements(v);
-                v.sort(nodesorter);
+                v.sort((void*)nodesorter);
                 fprintf(f, "<table border=0 cellspacing=0 cellpadding=3>\n");
                 loopv(i, v)
                 {
@@ -429,7 +429,7 @@ struct node : SlabAllocated<node>
         {
             Vector<node *> v;
             ht->getelements(v);
-            v.sort(nodesorter);
+            v.sort((void*)nodesorter);
             int timelevel = 0;
             if (v[0]->accum.seconds > 60) timelevel++;
             if (v[0]->accum.seconds > 60 * 60) timelevel++;
@@ -447,7 +447,7 @@ struct node : SlabAllocated<node>
     void merge(node &o)
     {
         for (lday *od = o.last; od; od = od->next)
-        {
+        { {
             for (lday *d = last; d; d = d->next)
             {
                 if (d->nday == od->nday)
@@ -459,7 +459,7 @@ struct node : SlabAllocated<node>
             lday *nd = new lday(NULL);
             *(daydata *)nd = *(daydata *)od;
             addtotail(nd);
-        daydone:;
+          } daydone:;
         }
 
         if (o.onechild)

--- a/src/procrastitracker.cpp
+++ b/src/procrastitracker.cpp
@@ -324,7 +324,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
                                     "Merge Database File Into Current Database..."))
                     {
                         String dir(requestfilename);
-                        auto char *it = requestfilename + dir.Len() + 1;
+                        char *it = requestfilename + dir.Len() + 1;
                         if (!*it)  // Single filename.
                         {
                             OutputDebugF("merging single file: \"%s\"\n", requestfilename);
@@ -336,7 +336,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
                             while (*it)
                             {
                                 String fn(dir.c_str());
-                                auto int len = strlen(it);
+                                int len = strlen(it);
                                 fn.Cat(it, len);
                                 it += len + 1;
                                 OutputDebugF("merging multiple files: \"%s\"\n", fn.c_str());

--- a/src/procrastitracker.cpp
+++ b/src/procrastitracker.cpp
@@ -11,6 +11,10 @@ SlabAlloc pool;
 #include "tools.h"
 StringPool strpool;
 
+#ifdef __MINGW32__
+#define sprintf_s snprintf
+#endif
+
 DWORD mainthreadid = 0;
 
 void warn(char *what)
@@ -320,7 +324,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
                                     "Merge Database File Into Current Database..."))
                     {
                         String dir(requestfilename);
-                        auto it = requestfilename + dir.Len() + 1;
+                        auto char *it = requestfilename + dir.Len() + 1;
                         if (!*it)  // Single filename.
                         {
                             OutputDebugF("merging single file: \"%s\"\n", requestfilename);
@@ -332,7 +336,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
                             while (*it)
                             {
                                 String fn(dir.c_str());
-                                auto len = strlen(it);
+                                auto int len = strlen(it);
                                 fn.Cat(it, len);
                                 it += len + 1;
                                 OutputDebugF("merging multiple files: \"%s\"\n", fn.c_str());
@@ -504,7 +508,11 @@ int APIENTRY _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCm
 
     lastsavetime = GetTickCount();
     lasttracktime = GetTickCount();
+#ifdef MINGW32_BUG
+    SetTimer(NULL, 0, prefs[PREF_SAMPLE].ival * 1000, timerfunc);
+#else
     SetTimer(NULL, NULL, prefs[PREF_SAMPLE].ival * 1000, timerfunc);
+#endif
     timer_sample_val = prefs[PREF_SAMPLE].ival;
 
     /*

--- a/src/statview.h
+++ b/src/statview.h
@@ -1,3 +1,11 @@
+#ifdef __MINGW32__
+#define max(a,b) ((a)>(b)?(a):(b))
+typedef struct tagTVKEYDOWN {
+  NMHDR hdr;
+  WORD  wVKey;
+  UINT  flags;
+} NMTVKEYDOWN, *LPNMTVKEYDOWN;
+#endif
 
 void setbar(int tag, HDC hdc)
 {

--- a/src/statview.h
+++ b/src/statview.h
@@ -1,10 +1,10 @@
 #ifdef __MINGW32__
-#define max(a,b) ((a)>(b)?(a):(b))
-typedef struct tagTVKEYDOWN {
-  NMHDR hdr;
-  WORD  wVKey;
-  UINT  flags;
-} NMTVKEYDOWN, *LPNMTVKEYDOWN;
+#include <windef.h>
+typedef TV_KEYDOWN NMTVKEYDOWN, *LPNMTVKEYDOWN;
+// MS VS (MSDN) and g++ (MinGW) use different names for this type
+// (the structure is defined in commctrl.h, included in stdafx.h);
+// the NMTVKEYDOWN is used since Windows Vista / Windows Server 2003
+// previous Windows versions used name TV_KEYDOWN, as MinGW does
 #endif
 
 void setbar(int tag, HDC hdc)

--- a/src/statview.h
+++ b/src/statview.h
@@ -1,5 +1,4 @@
 #ifdef __MINGW32__
-#include <windef.h>
 typedef TV_KEYDOWN NMTVKEYDOWN, *LPNMTVKEYDOWN;
 // MS VS (MSDN) and g++ (MinGW) use different names for this type
 // (the structure is defined in commctrl.h, included in stdafx.h);
@@ -249,7 +248,7 @@ long handleNotify(HWND hWndDlg, int nIDCtrl, LPNMHDR pNMHDR)
                                                     "Enter new amount of minutes to add to this node", buf, 100, false,
                                                     hWndDlg);
                         int newv = (int)selectednode->last->seconds + atoi(buf) * 60;
-                        selectednode->last->seconds = max(newv, 0);
+                        selectednode->last->seconds = std::max(newv, 0);
                         rendertree(hWndDlg, false);
                     }
                     return TRUE;

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -50,7 +50,7 @@
 #include <memory.h>
 #include <tchar.h>
 #include <stdio.h>
-#include <new.h>
+// #include <new.h>
 #include <math.h>
 #include <assert.h>
 

--- a/src/timercallback.h
+++ b/src/timercallback.h
@@ -1,7 +1,7 @@
 
 BOOL CALLBACK EnumChildWindowsCallback(HWND hWnd, LPARAM lp)
 {
-    auto procids = (DWORD *)lp;
+    auto DWORD *procids = (DWORD *)lp;
     DWORD pid = 0;
     GetWindowThreadProcessId(hWnd, &pid);
     if (pid != procids[0]) procids[1] = pid;

--- a/src/timercallback.h
+++ b/src/timercallback.h
@@ -1,7 +1,7 @@
 
 BOOL CALLBACK EnumChildWindowsCallback(HWND hWnd, LPARAM lp)
 {
-    auto DWORD *procids = (DWORD *)lp;
+    DWORD *procids = (DWORD *)lp;
     DWORD pid = 0;
     GetWindowThreadProcessId(hWnd, &pid);
     if (pid != procids[0]) procids[1] = pid;

--- a/src/tools.h
+++ b/src/tools.h
@@ -5,6 +5,10 @@ typedef unsigned int uint;
 static const float PI = 3.14159265358979323846264338327950288419716939937510f; // :)
 static const float RAD = PI/180.0f;
 
+#ifdef __MINGW32__
+#define min(a,b) ((a)<(b)?(a):(b))
+#endif
+
 #ifdef _DEBUG
 #define ASSERT(c) if(!(c)) { __asm int 3 }
 #else

--- a/src/tools.h
+++ b/src/tools.h
@@ -5,10 +5,6 @@ typedef unsigned int uint;
 static const float PI = 3.14159265358979323846264338327950288419716939937510f; // :)
 static const float RAD = PI/180.0f;
 
-#ifdef __MINGW32__
-#include <windef.h>
-#endif
-
 #ifdef _DEBUG
 #define ASSERT(c) if(!(c)) { __asm int 3 }
 #else
@@ -116,7 +112,7 @@ template <class T> class Vector : public NonCopyable
     int size()   { return ulen; }
 
     void setsize   (uint i) { while(ulen>i) drop(); }    // explicitly destruct elements
-    void setsize_nd(uint i) { ulen = min(ulen, i); }    
+    void setsize_nd(uint i) { ulen = std::min(ulen, i); }    
 
     void sort(void *cf) { qsort(buf, ulen, sizeof(T), (int (__cdecl *)(const void *, const void *))cf); }
     

--- a/src/tools.h
+++ b/src/tools.h
@@ -6,7 +6,7 @@ static const float PI = 3.14159265358979323846264338327950288419716939937510f; /
 static const float RAD = PI/180.0f;
 
 #ifdef __MINGW32__
-#define min(a,b) ((a)<(b)?(a):(b))
+#include <windef.h>
 #endif
 
 #ifdef _DEBUG


### PR DESCRIPTION
Needs fix for mousewheel, otherwise MinGW g++ shows compilation error.

To compile, set PATH to MinGW binaries, enter 'src' directory and type 'make'.

Except fix for mousewheel in src/IdleTracker.cpp the following changes were done:
src/Makefile - new
src/ddeutil.h - no CALLBACK before WinEventProc() if MINGW32_BUG defined
src/node.h - v.sort() arg type casted to void*; added {} to avoid forward goto within block
src/procrastitracker.cpp - sprintf_s defined as snprintf (MinGW only)
src/procrastitracker.cpp - 2X type specified where 'auto' type was used
src/procrastitracker.cpp - SetTimer arg2 0 instead NULL if MINGW32_BUG defined
src/statview.h - max() macro and struct tagTVKEYDOWN defined (MinGW only)
src/stdafx.h - removed #include <new.h>
src/timercallback.h - 1X type specified where 'auto' type was used
src/tools.h - min() macro defined (MinGW only)

"MinGW only" means detecting __MINGW32__ using ifdef

Tested on Windows XP SP3 - compiles, runs, shows user action statistics.
Two changes assumed to be workaround for MinGW bugs (type definition
in MinGW header files do not match the same object type in MSDN docs).