### PR TITLE
[CI] Update microsoft/setup-msbuild to 1.0.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1.0.2
     - name: build ProcrastiTracker
       run: |
         msbuild.exe procrastitracker\procrastitracker.sln /p:Configuration=Release /p:Platform=Win32


### PR DESCRIPTION
1.0.0 was causing error re: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

See: https://github.com/microsoft/setup-msbuild/issues/36