### PR TITLE
CI add filter on link to builds

### DIFF
--- a/PT/README.html
+++ b/PT/README.html
@@ -392,7 +392,7 @@
 
                   <tr><td>
                     Go
-                    <a href="https://github.com/aardappel/procrastitracker/actions"
+                    <a href="https://github.com/aardappel/procrastitracker/actions?query=branch%3Amaster+is%3Asuccess+event%3Apush"
                   class="style24">here</a>, click last commit with green checkmark in front, then click
                   "ProcrastiTracker (installer)".
                   </td></tr>


### PR DESCRIPTION
Currently, http://strlen.com/procrastitracker/#download links to a list of every CI build.

This is not ideal, as this includes builds from PRs. Some PR's might not be ready to be used, and it would be possible for someone to create a PR with malicious code, which would be bad.

This updated URL filters the CI builds to build on master, that succeed, and the commit is pushed(ie not a pr).