### PR TITLE
Fix and enable Chrome URL getting

### DIFF
--- a/src/ddeutil.h
+++ b/src/ddeutil.h
@@ -63,8 +63,8 @@ void CALLBACK WinEventProc
     char classname[MAXTMPSTR];
     GetClassName(hwnd, classname, MAXTMPSTR);
     classname[MAXTMPSTR - 1] = 0;
-    auto is_chrome = strcmp(classname, "Chrome_WidgetWin_1") != 0;
-    //auto is_firefox = strcmp(classname, "MozillaWindowClass") != 0;
+    auto is_chrome = strcmp(classname, "Chrome_WidgetWin_1") == 0;
+    //auto is_firefox = strcmp(classname, "MozillaWindowClass") == 0;
     if (!is_chrome /* && !is_firefox */) {
         //OutputDebugStringA("NOT CHROME\n");
         return;  // Early out.
@@ -169,9 +169,6 @@ void CALLBACK WinEventProc
 }
 
 void eventhookinit() {
-    // None of this code seems to work anymore, so don't run it.
-    return;
-
     if (LHook != 0) return;
     CoInitialize(NULL);
     LHook = SetWinEventHook(EVENT_OBJECT_FOCUS, EVENT_OBJECT_VALUECHANGE, 0, WinEventProc, 0, 0,
@@ -179,8 +176,6 @@ void eventhookinit() {
 }
 
 void eventhookclean() {
-    return;
-
     if (LHook == 0) return;
     UnhookWinEvent(LHook);
     CoUninitialize();

--- a/src/ddeutil.h
+++ b/src/ddeutil.h
@@ -63,7 +63,7 @@ void CALLBACK WinEventProc
     char classname[MAXTMPSTR];
     GetClassName(hwnd, classname, MAXTMPSTR);
     classname[MAXTMPSTR - 1] = 0;
-    auto is_chrome = strcmp(classname, "Chrome_WidgetWin_1") == 0;
+    auto is_chrome = strcmp(classname, "Chrome_WidgetWin_1") == 0;  // This can also be MS Edge
     //auto is_firefox = strcmp(classname, "MozillaWindowClass") == 0;
     if (!is_chrome /* && !is_firefox */) {
         //OutputDebugStringA("NOT CHROME\n");

--- a/src/timercallback.h
+++ b/src/timercallback.h
@@ -115,12 +115,12 @@ VOID CALLBACK timerfunc(HWND hwnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime) {
         if (strcmp(exename, "firefox") == 0 || strcmp(exename, "iexplore") == 0 ||
             strcmp(exename, "chrome") == 0 || strcmp(exename, "opera") == 0 ||
             strcmp(exename, "netscape") == 0 || strcmp(exename, "netscape6") == 0 ||
-            strcmp(exename, "microsoftedge") == 0) {
+            strcmp(exename, "msedge") == 0) {
             // TODO: can we get a UTF-8 URL out of this somehow, if the URL contains percent encoded
             // unicode chars?
             ddereq(exename, "WWW_GetWindowInfo", "0xFFFFFFFF", url, MAXTMPSTR);
             if (!*url) {
-                if (!strcmp(exename, "chrome")) {
+                if (!strcmp(exename, "chrome") || !strcmp(exename, "msedge")) {
                     // Chrome doesn't support DDE, get last url change from it:
                     strncpy(url, current_chrome_url, MAXTMPSTR);
                 }


### PR DESCRIPTION
The bug was caused by a hard to spot error where `!= 0` was used instead of `== 0` on the output of `strcmp` to indicate equality.

Unless I missed something, I think this fixes #65.